### PR TITLE
Add a custom monolog formatter for Nutgram

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "php": "^8.2",
     "nunomaduro/termwind": "^1.15",
-    "nutgram/nutgram": "^4.6.0"
+    "nutgram/nutgram": "^4.11.0"
   },
   "require-dev": {
     "illuminate/testing": "^9.0|^10.0",

--- a/resources/views/logging/request.blade.php
+++ b/resources/views/logging/request.blade.php
@@ -1,0 +1,8 @@
+<div class="mb-1">
+    <div>
+        <span class="px-1 bg-yellow-500 text-black">{{$time}}</span>
+        <span class="mx-1">{{$message}}</span>
+        <span class="px-1 bg-green-500 text-black">{{$endpoint}}</span>
+    </div>
+    <div class="text-gray-500">{{$content}}</div>
+</div>

--- a/resources/views/logging/response.blade.php
+++ b/resources/views/logging/response.blade.php
@@ -1,0 +1,8 @@
+<div class="mb-1">
+    <div>
+        <span class="px-1 bg-yellow-500 text-black">{{$time}}</span>
+        <span class="mx-1">{{$message}}</span>
+    </div>
+    <div class="text-gray-500">{{$response}}</div>
+    <div class="content-repeat-['.']"></div>
+</div>

--- a/src/Log/NutgramFormatter.php
+++ b/src/Log/NutgramFormatter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Nutgram\Laravel\Log;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+use function Termwind\{render};
+
+class NutgramFormatter implements FormatterInterface
+{
+    public function format(LogRecord $record): void
+    {
+        $record->context['type'] === 'request' ? $this->formatRequest($record) : $this->formatResponse($record);
+    }
+
+    public function formatBatch(array $records): void
+    {
+        array_walk($records, [$this, 'format']);
+    }
+
+    public function formatRequest(LogRecord $record): void
+    {
+        $content = json_encode($record->context['content'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        render(view('logging::request', [
+            'time' => $record->datetime->format('Y-m-d H:i:s'),
+            'message' => $record->message,
+            'endpoint' => $record->context['endpoint'],
+            'content' => $content,
+        ]));
+    }
+
+    public function formatResponse(LogRecord $record): void
+    {
+        $response = json_encode($record->context['response'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        render(view('logging::response', [
+            'time' => $record->datetime->format('Y-m-d H:i:s'),
+            'message' => $record->message,
+            'response' => $response,
+        ]));
+    }
+}

--- a/src/NutgramServiceProvider.php
+++ b/src/NutgramServiceProvider.php
@@ -86,6 +86,7 @@ class NutgramServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->loadViewsFrom(__DIR__.'/../resources/views/terminal', 'terminal');
+            $this->loadViewsFrom(__DIR__.'/../resources/views/logging', 'logging');
 
             $this->commands([
                 Console\RunCommand::class,


### PR DESCRIPTION
This PR adds a custom monolog formatter for Nutgram. 
It's a simple formatter that shows the date, the message, the endpoint and the content/response.

## Before this PR

`.env` file:
```dotenv
TELEGRAM_LOG_CHANNEL=stderr
```

![immagine](https://github.com/nutgram/laravel/assets/4071613/0adc788c-b787-4003-95b8-f82c13a5436d)


## After this PR

`config/logging.php` file:
```php
// [...]
'channels' => [
    // [...]
    'nutgram' => [
        'driver' => 'monolog',
        'level' => env('LOG_LEVEL', 'debug'),
        'handler' => StreamHandler::class,
        'formatter' => NutgramFormatter::class,
        'with' => [
            'stream' => 'php://stderr',
        ],
        'processors' => [PsrLogMessageProcessor::class],
    ],
]
```

`.env` file:
```dotenv
TELEGRAM_LOG_CHANNEL=nutgram
```

![immagine](https://github.com/nutgram/laravel/assets/4071613/360b5140-a854-4ee0-9b1b-d203585b4555)
