### PR TITLE
Add `--watch` option to `nutgram:run` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
   "require": {
     "php": "^8.2",
     "nunomaduro/termwind": "^1.0|^2.0",
-    "nutgram/nutgram": "^4.17.0"
+    "nutgram/nutgram": "^4.17.0",
+    "spatie/file-system-watcher": "^1.2"
   },
   "require-dev": {
     "illuminate/testing": "^9.0|^10.0|^11.0|^12.0",

--- a/config/nutgram.php
+++ b/config/nutgram.php
@@ -23,8 +23,17 @@ return [
     // Set log channel
     'log_channel' => env('TELEGRAM_LOG_CHANNEL', 'null'),
 
-    // Watch paths used by the "nutgram:run --watch" command
-    'watch_paths' => [
-        app_path('Telegram'),
+    // Watch options used by the "nutgram:run --watch" command
+    'watch' => [
+
+        // The paths to watch for changes
+        'paths' => [
+            app_path('Telegram'),
+        ],
+
+        // The extensions to watch for changes
+        'extensions' => [
+            'php',
+        ],
     ],
 ];

--- a/config/nutgram.php
+++ b/config/nutgram.php
@@ -23,17 +23,8 @@ return [
     // Set log channel
     'log_channel' => env('TELEGRAM_LOG_CHANNEL', 'null'),
 
-    // Watch configs used by the "nutgram:run --watch" command
-    'watch' => [
-        // PHP binary to use
-        'bin' => PHP_BINARY,
-
-        // Interval in microseconds to check for changes
-        'interval' => 250 * 1000,
-
-        // Paths to watch
-        'paths' => [
-            app_path('Telegram'),
-        ]
+    // Watch paths used by the "nutgram:run --watch" command
+    'watch_paths' => [
+        app_path('Telegram'),
     ],
 ];

--- a/config/nutgram.php
+++ b/config/nutgram.php
@@ -22,4 +22,18 @@ return [
 
     // Set log channel
     'log_channel' => env('TELEGRAM_LOG_CHANNEL', 'null'),
+
+    // Watch configs used by the "nutgram:run --watch" command
+    'watch' => [
+        // PHP binary to use
+        'bin' => PHP_BINARY,
+
+        // Interval in microseconds to check for changes
+        'interval' => 250 * 1000,
+
+        // Paths to watch
+        'paths' => [
+            app_path('Telegram'),
+        ]
+    ],
 ];

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -50,7 +50,7 @@ class RunCommand extends Command
 
     protected function startWatchProcess(): void
     {
-        $this->watchProcess = Process::start(
+        $this->watchProcess = Process::tty(Process::supportsTty())->start(
             command: config('nutgram.watch.bin', PHP_BINARY).' artisan nutgram:run',
             output: function (string $type, string $output) {
                 $this->output->write($output);

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -80,14 +80,10 @@ class RunCommand extends Command
 
     protected function restartAsyncRun(): self
     {
-        $this->components->info('Change detected! Restarting bot...');
+        $this->components->info('Changes detected! Restarting bot...');
 
         $this->runProcess->stop();
-        $this->runProcess->wait(function (string $type, string $output) {
-            if(Process::isTtySupported() && !$this->option('without-tty')) {
-                $this->output->write($output);
-            }
-        });
+        $this->runProcess->wait();
 
         $this->startAsyncRun();
 

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -54,8 +54,6 @@ class RunCommand extends Command
             }
         });
 
-        sleep(1);
-
         return ! $this->runProcess->isTerminated();
     }
 

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -3,15 +3,20 @@
 namespace Nutgram\Laravel\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Process\InvokedProcess;
+use Illuminate\Support\Facades\Process;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use SergiX44\Nutgram\Nutgram;
+use Spatie\Watcher\Watch;
 
 class RunCommand extends Command
 {
-    protected $signature = 'nutgram:run';
+    protected $signature = 'nutgram:run {--watch : Watch for changes and restart the bot}';
 
     protected $description = 'Start the bot in long polling mode';
+
+    protected ?InvokedProcess $watchProcess = null;
 
     /**
      * @throws ContainerExceptionInterface
@@ -19,6 +24,39 @@ class RunCommand extends Command
      */
     public function handle(Nutgram $bot): void
     {
+        if ($this->option('watch')) {
+            $this->watch();
+
+            return;
+        }
+
         $bot->run();
+    }
+
+    protected function watch(): void
+    {
+        $this->info('Watching for changes...');
+        $this->startWatchProcess();
+
+        Watch::paths(...config('nutgram.watch.paths', []))
+            ->setIntervalTime(config('nutgram.watch.interval', 250 * 1000))
+            ->onAnyChange(function () {
+                $this->warn('Restarting the bot...');
+                $this->watchProcess?->stop();
+                $this->startWatchProcess();
+            })
+            ->start();
+    }
+
+    protected function startWatchProcess(): void
+    {
+        $this->watchProcess = Process::start(
+            command: config('nutgram.watch.bin', PHP_BINARY).' artisan nutgram:run',
+            output: function (string $type, string $output) {
+                $this->output->write($output);
+            }
+        );
+
+        $this->output->write($this->watchProcess->output());
     }
 }

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -56,7 +56,5 @@ class RunCommand extends Command
                 $this->output->write($output);
             }
         );
-
-        $this->output->write($this->watchProcess->output());
     }
 }


### PR DESCRIPTION
This PR adds a `--watch` option to the `nutgram:run` command, which allows you to run the bot in watch mode. 
This means that the bot will automatically restart whenever you make changes to the code, 
making it easier to develop and test your bot.

## Usage
To use the `--watch` option, simply run the following command:

```bash
php artisan nutgram:run --watch
```

## Requirements
In your project, you should have the JavaScript package chokidar installed. You can install it via npm

```bash
npm install chokidar
```

or Yarn

```bash
yarn add chokidar
```

## Configuration
You can configure the watch command in your `config/nutgram.php` file.
```php
// ...

// Watch options used by the "nutgram:run --watch" command
'watch' => [

    // The paths to watch for changes
    'paths' => [
        app_path('Telegram'),
    ],

    // The extensions to watch for changes
    'extensions' => [
        'php',
    ],
],
```