### PR TITLE
Listen command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "php": "^8.2",
     "nunomaduro/termwind": "^1.0|^2.0",
-    "nutgram/nutgram": "dev-single-polling-update"
+    "nutgram/nutgram": "^4.20"
   },
   "require-dev": {
     "illuminate/testing": "^9.0|^10.0|^11.0|^12.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "php": "^8.2",
     "nunomaduro/termwind": "^1.0|^2.0",
-    "nutgram/nutgram": "^4.17.0"
+    "nutgram/nutgram": "dev-single-polling-update"
   },
   "require-dev": {
     "illuminate/testing": "^9.0|^10.0|^11.0|^12.0",

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -3,6 +3,7 @@
 namespace Nutgram\Laravel\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Facades\App;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\RunningMode\SingleUpdate;
@@ -13,7 +14,7 @@ class ListenCommand extends Command
 
     protected $description = 'Start the bot for development and reloads after every update.';
 
-    public function handle(): void
+    public function handle(Container $container): void
     {
         while (true) {
             App::forgetInstance(Nutgram::class);

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -8,7 +8,7 @@ use SergiX44\Nutgram\RunningMode\SingleUpdate;
 
 class ListenCommand extends Command
 {
-    protected $signature = 'nutgram:listen {--pollingTimeout=1}';
+    protected $signature = 'nutgram:listen {--pollingTimeout=5}';
 
     protected $description = 'Start the bot for development and reloads after every update.';
 
@@ -16,9 +16,7 @@ class ListenCommand extends Command
     {
         $this->warn('This running mode is very inefficient and only suitable for development purposes. DO NOT USE IN PRODUCTION!');
         $this->info('Listening...');
-
-        $pollingTimeout = $this->option('pollingTimeout') ?: 1;
-        config()?->set('nutgram.config.polling.timeout', $pollingTimeout);
+        config()?->set('nutgram.config.polling.timeout', $this->option('pollingTimeout'));
         while (true) {
             if (function_exists('opcache_reset')) {
                 opcache_reset();

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -3,7 +3,6 @@
 namespace Nutgram\Laravel\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Facades\App;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\RunningMode\SingleUpdate;
@@ -14,11 +13,11 @@ class ListenCommand extends Command
 
     protected $description = 'Start the bot for development and reloads after every update.';
 
-    public function handle(Container $container): void
+    public function handle(): void
     {
         while (true) {
-            App::forgetInstance(Nutgram::class);
-            $bot = App::make(Nutgram::class);
+            $app = App::configure(base_path())->create();
+            $bot = $app->make(Nutgram::class);
             $bot->setRunningMode(SingleUpdate::class);
             $bot->run();
         }

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nutgram\Laravel\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\App;
+use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\RunningMode\SingleUpdate;
+
+class ListenCommand extends Command
+{
+    protected $signature = 'nutgram:listen';
+
+    protected $description = 'Start the bot for development and reloads after every update.';
+
+    public function handle(): void
+    {
+        while (true) {
+            App::forgetInstance(Nutgram::class);
+            $bot = App::make(Nutgram::class);
+            $bot->setRunningMode(SingleUpdate::class);
+            $bot->run();
+        }
+    }
+}

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -3,7 +3,6 @@
 namespace Nutgram\Laravel\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\App;
 use SergiX44\Nutgram\Nutgram;
 use SergiX44\Nutgram\RunningMode\SingleUpdate;
 
@@ -17,8 +16,8 @@ class ListenCommand extends Command
     {
         $this->info('Listening...');
         while (true) {
-            $app = App::configure(base_path())->create();
-            $bot = $app->make(Nutgram::class);
+            app()->forgetInstance(Nutgram::class);
+            $bot = app(Nutgram::class);
             $bot->setRunningMode(SingleUpdate::class);
             $bot->run();
         }

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -15,6 +15,7 @@ class ListenCommand extends Command
 
     public function handle(): void
     {
+        $this->info('Listening...');
         while (true) {
             $app = App::configure(base_path())->create();
             $bot = $app->make(Nutgram::class);

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -5,7 +5,7 @@ namespace Nutgram\Laravel\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Process;
 use function Illuminate\Support\artisan_binary;
-use function Orchestra\Testbench\php_binary;
+use function Illuminate\Support\php_binary;
 
 class ListenCommand extends Command
 {

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -18,13 +18,14 @@ class ListenCommand extends Command
         $this->warn('This running mode is very inefficient and only suitable for development purposes. DO NOT USE IN PRODUCTION!');
         $this->info('Listening...');
         while (true) {
-            $result = Process::run([
+            $result = Process::start([
                 php_binary(), artisan_binary(), 'nutgram:run', '--once',
                 '--pollingTimeout='.$this->option('pollingTimeout'),
-            ]);
+            ], function (string $type, string $output) {
+                $this->output->write($output);
+            })->wait();
             if ($result->exitCode() !== 0) {
-                $this->line($result->output());
-                $this->error($result->errorOutput());
+                $this->error('An error occurred while running the bot. Exiting...');
                 break;
             }
         }

--- a/src/Console/ListenCommand.php
+++ b/src/Console/ListenCommand.php
@@ -8,14 +8,21 @@ use SergiX44\Nutgram\RunningMode\SingleUpdate;
 
 class ListenCommand extends Command
 {
-    protected $signature = 'nutgram:listen';
+    protected $signature = 'nutgram:listen {--pollingTimeout=1}';
 
     protected $description = 'Start the bot for development and reloads after every update.';
 
     public function handle(): void
     {
+        $this->warn('This running mode is very inefficient and only suitable for development purposes. DO NOT USE IN PRODUCTION!');
         $this->info('Listening...');
+
+        $pollingTimeout = $this->option('pollingTimeout') ?: 1;
+        config()?->set('nutgram.config.polling.timeout', $pollingTimeout);
         while (true) {
+            if (function_exists('opcache_reset')) {
+                opcache_reset();
+            }
             app()->forgetInstance(Nutgram::class);
             $bot = app(Nutgram::class);
             $bot->setRunningMode(SingleUpdate::class);

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -6,10 +6,11 @@ use Illuminate\Console\Command;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use SergiX44\Nutgram\Nutgram;
+use SergiX44\Nutgram\RunningMode\SingleUpdate;
 
 class RunCommand extends Command
 {
-    protected $signature = 'nutgram:run';
+    protected $signature = 'nutgram:run {--once} {--pollingTimeout=}';
 
     protected $description = 'Start the bot in long polling mode';
 
@@ -19,6 +20,15 @@ class RunCommand extends Command
      */
     public function handle(Nutgram $bot): void
     {
+        if ($pollingTimeout = $this->option('pollingTimeout')) {
+            config()?->set('nutgram.config.polling.timeout', (int)$pollingTimeout);
+            $this->info("Polling set to {$pollingTimeout} seconds.");
+        }
+
+        if ($this->option('once')) {
+            $bot->setRunningMode(SingleUpdate::class);
+        }
+
         $bot->run();
     }
 }

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -22,7 +22,6 @@ class RunCommand extends Command
     {
         if ($pollingTimeout = $this->option('pollingTimeout')) {
             config()?->set('nutgram.config.polling.timeout', (int)$pollingTimeout);
-            $this->info("Polling set to {$pollingTimeout} seconds.");
         }
 
         if ($this->option('once')) {

--- a/src/NutgramServiceProvider.php
+++ b/src/NutgramServiceProvider.php
@@ -82,8 +82,8 @@ class NutgramServiceProvider extends ServiceProvider
         });
 
         $this->app->alias(Nutgram::class, 'nutgram');
+        $this->app->alias(Nutgram::class, 'telegram');
         $this->app->alias(Nutgram::class, FakeNutgram::class);
-        $this->app->singleton('telegram', fn (Application $app) => $app->get(Nutgram::class));
 
         if (config('nutgram.mixins', false)) {
             Nutgram::mixin(new Mixins\NutgramMixin());

--- a/src/NutgramServiceProvider.php
+++ b/src/NutgramServiceProvider.php
@@ -74,7 +74,7 @@ class NutgramServiceProvider extends ServiceProvider
         });
 
         $this->app->resolving(Nutgram::class, function (Nutgram $bot, Application $app) {
-            if (config('nutgram.routes', false) && !$app->resolved($bot::class)) {
+            if (config('nutgram.routes', false)) {
                 (function () use ($bot) {
                     require file_exists($this->telegramRoutes) ? $this->telegramRoutes : self::ROUTES_PATH;
                 })();

--- a/src/NutgramServiceProvider.php
+++ b/src/NutgramServiceProvider.php
@@ -73,6 +73,14 @@ class NutgramServiceProvider extends ServiceProvider
             return $bot;
         });
 
+        $this->app->resolving(Nutgram::class, function (Nutgram $bot, Application $app) {
+            if (config('nutgram.routes', false) && !$app->resolved($bot::class)) {
+                (function () use ($bot) {
+                    require file_exists($this->telegramRoutes) ? $this->telegramRoutes : self::ROUTES_PATH;
+                })();
+            }
+        });
+
         $this->app->alias(Nutgram::class, 'nutgram');
         $this->app->alias(Nutgram::class, FakeNutgram::class);
         $this->app->singleton('telegram', fn (Application $app) => $app->get(Nutgram::class));
@@ -110,11 +118,6 @@ class NutgramServiceProvider extends ServiceProvider
                 self::CONFIG_PATH => config_path('nutgram.php'),
                 self::ROUTES_PATH => $this->telegramRoutes,
             ], 'nutgram');
-        }
-
-        if (config('nutgram.routes', false)) {
-            $bot = $this->app->get(Nutgram::class);
-            require file_exists($this->telegramRoutes) ? $this->telegramRoutes : self::ROUTES_PATH;
         }
     }
 }

--- a/src/NutgramServiceProvider.php
+++ b/src/NutgramServiceProvider.php
@@ -100,6 +100,7 @@ class NutgramServiceProvider extends ServiceProvider
 
             $this->commands([
                 Console\RunCommand::class,
+                Console\ListenCommand::class,
                 Console\RegisterCommandsCommand::class,
                 Console\HookInfoCommand::class,
                 Console\HookRemoveCommand::class,


### PR DESCRIPTION
# After only 1 year stuck on my PC...

This pull request introduces updates to the `nutgram/nutgram` dependency, adds a new console command for development purposes, and refactors how Telegram routes are loaded in the service provider. Below are the most important changes grouped by theme:

### Dependency Update:
* Updated the `nutgram/nutgram` dependency in `composer.json` from version `^4.17.0` to `^4.20` to ensure compatibility with the latest features and fixes.

### New Feature:
* Added a new `ListenCommand` class in `src/Console/ListenCommand.php` to enable development-friendly bot listening with automatic reloads after every update. This command is intended for development only and warns against use in production environments.

### Service Provider Enhancements:
* Refactored the `register` method in `NutgramServiceProvider` to dynamically load Telegram routes when the `nutgram.routes` configuration is enabled. This replaces the previous approach of loading routes directly in the `boot` method.
* Registered the new `ListenCommand` in the `boot` method of `NutgramServiceProvider`, making it available as part of the application's console commands.
* Removed the redundant Telegram route loading logic from the `boot` method of `NutgramServiceProvider`, as it is now handled during the resolution of the `Nutgram` instance.